### PR TITLE
Changed some options from vim.o to vim.bo

### DIFF
--- a/lua/galaxyline/provider_fileinfo.lua
+++ b/lua/galaxyline/provider_fileinfo.lua
@@ -2,10 +2,10 @@ local vim = vim
 local M = {}
 
 local function file_readonly()
-  if vim.o.filetype == 'help' then
+  if vim.bo.filetype == 'help' then
     return ''
   end
-  if vim.o.readonly == true then
+  if vim.bo.readonly == true then
     return " "
   end
   return ''
@@ -18,7 +18,7 @@ function M.get_current_file_name()
   if string.len(file_readonly()) ~= 0 then
     return file .. file_readonly()
   end
-  if vim.o.modifiable then
+  if vim.bo.modifiable then
     if vim.bo.modified then
       return file .. '   '
     end
@@ -52,13 +52,13 @@ end
 
 -- get file encode
 function M.get_file_encode()
-  local encode = vim.o.fenc ~= '' and vim.o.fenc or vim.o.enc
+  local encode = vim.bo.fenc ~= '' and vim.bo.fenc or vim.bo.enc
   return ' ' .. encode
 end
 
 -- get file format
 function M.get_file_format()
-  return vim.o.fileformat
+  return vim.bo.fileformat
 end
 
 -- show line:column


### PR DESCRIPTION
All those options are local to buffers. Discovered since the "lock" icon didn't appear on readonly files