### PR TITLE
Fix inactive LSP causing errors

### DIFF
--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -19,9 +19,12 @@ local function get_nvim_lsp_diagnostic(diag_type)
   local active_clients = lsp.get_active_clients()
 
   if active_clients then
-    local client_id = active_clients[1].id
-    local bufnr = api.nvim_get_current_buf()
-    local count = lsp.diagnostic.get_count(bufnr,diag_type,client_id)
+    local count = 0
+
+    for _, client in ipairs(active_clients) do
+       count = count + lsp.diagnostic.get_count(api.nvim_get_current_buf(),diag_type,client.id)
+    end
+
     if count ~= 0 then return count end
   end
 end

--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -15,10 +15,15 @@ end
 -- see https://github.com/neovim/nvim-lspconfig
 local function get_nvim_lsp_diagnostic(diag_type)
   if vim.tbl_isempty(lsp.buf_get_clients(0)) then return '' end
-  local client_id = lsp.get_active_clients()[1].id
-  local bufnr = api.nvim_get_current_buf()
-  local count = lsp.diagnostic.get_count(bufnr,diag_type,client_id)
-  if count ~= 0 then return count end
+
+  local active_clients = lsp.get_active_clients()
+
+  if active_clients then
+    local client_id = active_clients[1].id
+    local bufnr = api.nvim_get_current_buf()
+    local count = lsp.diagnostic.get_count(bufnr,diag_type,client_id)
+    if count ~= 0 then return count end
+  end
 end
 
 function M.get_diagnostic_error()


### PR DESCRIPTION
When switching buffers from one with an active LSP to one without an LSP, I was getting errors that looked like this:

![Errors](https://user-images.githubusercontent.com/36409591/99109702-36966180-25b7-11eb-8d69-b714609a0e86.png)

This PR does two things:

1. Fix the error.
2. Allow summation of errors from all active LSPs in the buffer.