### PR TITLE
Fix bug in git submodule branch resolution

### DIFF
--- a/lua/galaxyline/provider_vcs.lua
+++ b/lua/galaxyline/provider_vcs.lua
@@ -60,7 +60,8 @@ function M.get_git_dir(path)
 
     -- Checks if provided directory contains git directory
     local function has_git_dir(dir)
-        if  common.is_dir(dir..'/.git') then return dir end
+        local git_dir = dir..'/.git'
+        if common.is_dir(git_dir) then return git_dir end
     end
 
     local function has_git_file(dir)
@@ -121,9 +122,8 @@ function M.get_git_branch()
       return  gitbranch_pwd
     end
   end
-  local git_root = M.get_git_dir(current_dir)
-  if not git_root then return end
-  local git_dir = git_root .. '/.git'
+  local git_dir = M.get_git_dir(current_dir)
+  if not git_dir then return end
 
   -- If git directory not found then we're probably outside of repo
   -- or something went wrong. The same is when head_file is nil


### PR DESCRIPTION
**Description**

This PR fixes an issue in the branch name resolution logic in the vcs provider.

Basically, when you are within a git submodule the `.git` file points to the git directory and that is being returned from `has_git_file` whereas `has_git_dir` is returning the project root (the one that contains the `.git` within it. Later it is assumed that `/.git` should be appended however we don't want to that for submodules, instead we consistently return the git directory from both `has_git_dir` and `has_git_file`

Thank you for this awesome plugin!