### PR TITLE
Add requirement for neovim version to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ galaxyline is a light-weight and super fast statusline plugin ,galaxyline compon
 
 Means you can use the api provided by galaxyline to make the statusline that you want easily.
 
+**Require neovim 5.0+**
+
 ## Install
 * vim-plug
 ```vim


### PR DESCRIPTION
Since neovim 5.0 is not yet released it's better to add this information to the readme (prevent losing time with error messages and issues)