### PR TITLE
cast to number for comparison with 0

### DIFF
--- a/lua/galaxyline/provider_vcs.lua
+++ b/lua/galaxyline/provider_vcs.lua
@@ -166,9 +166,9 @@ local function get_hunks_data()
     return diff_data
   elseif vim.fn.exists('b:gitsigns_status') == 1 then
     local gitsigns_dict = vim.api.nvim_buf_get_var(0, 'gitsigns_status')
-    diff_data[1] = gitsigns_dict:match('+?(%d+)') or 0
-    diff_data[2] = gitsigns_dict:match('%s~?(%d+)') or 0
-    diff_data[3] = gitsigns_dict:match('-(%d+)') or 0
+    diff_data[1] = tonumber(gitsigns_dict:match('+?(%d+)')) or 0
+    diff_data[2] = tonumber(gitsigns_dict:match('%s~?(%d+)')) or 0
+    diff_data[3] = tonumber(gitsigns_dict:match('-(%d+)')) or 0
   end
   return diff_data
 end


### PR DESCRIPTION
bug fix in https://github.com/glepnir/galaxyline.nvim/commit/eb53575028cac7dc549ab9c6f6d3d243d37a4b05

Without this change, it occurs error at https://github.com/glepnir/galaxyline.nvim/blob/eb53575028cac7dc549ab9c6f6d3d243d37a4b05/lua/galaxyline/provider_vcs.lua#L178 because it can not compare string with number.