### PR TITLE
fix: update on InsertEnter event

### DIFF
--- a/lua/galaxyline.lua
+++ b/lua/galaxyline.lua
@@ -227,7 +227,7 @@ function M.disable_galaxyline()
 end
 
 function M.galaxyline_augroup()
-  local events = { 'FileType','BufWinEnter','BufReadPost','BufWritePost','BufEnter','WinEnter','FileChangedShellPost','VimResized' }
+  local events = { 'InsertEnter','FileType','BufWinEnter','BufReadPost','BufWritePost','BufEnter','WinEnter','FileChangedShellPost','VimResized' }
   vim.api.nvim_command('augroup galaxyline')
   vim.api.nvim_command('autocmd!')
   for _, def in ipairs(events) do


### PR DESCRIPTION
Currently the mode provider only updates to show insert mode once the
cursor is moved inside insert mode. This will show the change
immediately.