### PR TITLE
fix startup error when WebDevIconsGetFileTypeSymbol does not exist

### DIFF
--- a/lua/galaxyline/provider_fileinfo.lua
+++ b/lua/galaxyline/provider_fileinfo.lua
@@ -133,7 +133,7 @@ function M.get_file_icon()
     return icon .. ' '
   end
   local ok,devicons = pcall(require,'nvim-web-devicons')
-  if not ok then print('No icon plugin found. Please install \'kyazdani42/nvim-web-devicons\'') return end
+  if not ok then print('No icon plugin found. Please install \'kyazdani42/nvim-web-devicons\'') return '' end
   local f_name,f_extension = vim.fn.expand('%:t'),vim.fn.expand('%:e')
   icon = devicons.get_icon(f_name,f_extension)
   if icon == nil then


### PR DESCRIPTION
<img width="1254" alt="Screen Shot 2021-01-09 at 16 58 27" src="https://user-images.githubusercontent.com/4605383/104094812-ecbab680-529b-11eb-89f5-1920ce30b150.png">
