### PR TITLE
Update provider_extensions.lua

### DIFF
--- a/lua/galaxyline/provider_extensions.lua
+++ b/lua/galaxyline/provider_extensions.lua
@@ -28,7 +28,7 @@ end
 function M.vista_nearest(vista_icon)
   local has_vista,vista_info = pcall(vim.fn.nvim_buf_get_var,0,'vista_nearest_method_or_function')
   if not has_vista then return end
-  local icon = vista_icon or '✪'
+  local icon = vista_icon or '✪ '
   return icon .. vista_info
 end
 


### PR DESCRIPTION
The additional space in the vista icon is necessary to avoid that it cover the vista method.