### PR TITLE
Make sure `short_line` is set

### DIFF
--- a/lua/galaxyline.lua
+++ b/lua/galaxyline.lua
@@ -222,10 +222,11 @@ async_combin = uv.new_async(vim.schedule_wrap(function()
   local short_left_section = load_section(M.section.short_line_left,'left')
   local short_right_section = load_section(M.section.short_line_right,'right')
   local line = ''
-  if not common.has_value(M.short_line_list,vim.bo.filetype) then
-    line = left_section .. '%=' .. right_section
-  else
-    short_line =  short_left_section .. '%=' .. short_right_section
+
+  line = left_section .. '%=' .. right_section
+  short_line =  short_left_section .. '%=' .. short_right_section
+
+  if common.has_value(M.short_line_list,vim.bo.filetype) then
     line = short_line
   end
 


### PR DESCRIPTION
Fixes #105

It seems like `short_line` wasn't being set on load. This fixes that so that an inactive split has something to display.