### PR TITLE
Fix: lock insufficient spacing

### DIFF
--- a/lua/galaxyline/provider_fileinfo.lua
+++ b/lua/galaxyline/provider_fileinfo.lua
@@ -6,7 +6,7 @@ local function file_readonly()
     return ''
   end
   if vim.bo.readonly == true then
-    return " "
+    return "  "
   end
   return ''
 end


### PR DESCRIPTION
Adding a space after the locksign in the `provider_fileinfo.lua` `file_readonly` function. This should fix the problem of insufficient spacing.
Showcase of the problem (left window):
![lock_does_not_have_space](https://user-images.githubusercontent.com/56647779/110108996-2e07a800-7dad-11eb-8723-e9f99e060f15.png)
