### PR TITLE
Allow component_info.icon to be a function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ You can also use the source of the provider function.
     will load the component.
 
 - `icon` is a string that will be added to the head of the provider result.
+    It can also be a function that returns a string.
 
 - `highlight` can be used in two ways.  The first is to pass three elements: the first element is `fg`, the second is `bg`, and the third is `gui`. The second method is to pass a highlight group as a string (such as `IncSearch`) that galaxyline will link to.
 

--- a/lua/galaxyline.lua
+++ b/lua/galaxyline.lua
@@ -40,7 +40,8 @@ end
 
 -- component decorator
 -- that will output the component result with icon
--- component provider and icon can be string or table
+-- component provider can be string or table
+-- component icon can be string or function
 function M.component_decorator(component_name)
   -- if section doesn't have component just return
   local ok,component_info = check_component_exists(component_name)
@@ -50,6 +51,8 @@ function M.component_decorator(component_name)
   end
   local provider = component_info.provider or ''
   local icon = component_info.icon or ''
+  if type(icon) == 'function' then icon = icon() end
+  if type(icon) ~= 'string' then icon = '' end
 
   local _switch = {
     ['string'] = function()


### PR DESCRIPTION
Simple change to allow component_info.icon to be a function.