### PR TITLE
fix: closing nvim-tree reloads galaxyline

### DIFF
--- a/lua/galaxyline.lua
+++ b/lua/galaxyline.lua
@@ -157,7 +157,7 @@ end
 
 local hi_tbl = {}
 local events = { 'ColorScheme', 'FileType','BufWinEnter','BufReadPost','BufWritePost',
-                  'BufEnter','WinEnter','FileChangedShellPost','VimResized','TermOpen'}
+                  'BufEnter','WinEnter','FileChangedShellPost','VimResized','TermOpen', 'BufHidden'}
 
 local function load_section(section_area,pos)
   local section = ''


### PR DESCRIPTION
fixes #172 
Added BufHidden to events list so that closing nvim-tree reloads galaxyline.

Here is how it works after the fix

https://user-images.githubusercontent.com/43147494/120064436-bedae080-c089-11eb-96f2-0bc41704f7fb.mp4

