### PR TITLE
Reusable diagnostic function

### DIFF
--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -28,40 +28,29 @@ local function get_nvim_lsp_diagnostic(diag_type)
   end
 end
 
-function M.get_diagnostic_error()
+local function get_diagnostic(diag_type)
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
-    return get_coc_diagnostic('error')
+    return get_coc_diagnostic(diag_type:lower())
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Error')
+    return get_nvim_lsp_diagnostic(diag_type)
   end
   return ''
+end
+
+function M.get_diagnostic_error()
+  return get_diagnostic('Error')
 end
 
 function M.get_diagnostic_warn()
-  if vim.fn.exists('*coc#rpc#start_server') == 1 then
-    return get_coc_diagnostic('warning')
-  elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Warning')
-  end
-  return ''
+  return get_diagnostic('Warning')
 end
 
 function M.get_diagnostic_hint()
-  if vim.fn.exists('*coc#rpc#start_server') == 1 then
-    return get_coc_diagnostic('hint')
-  elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Hint')
-  end
-  return ''
+  return get_diagnostic('Hint')
 end
 
 function M.get_diagnostic_info()
-  if vim.fn.exists('*coc#rpc#start_server') == 1 then
-    return get_coc_diagnostic('information')
-  elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Information')
-  end
-  return ''
+  return get_diagnostic('Information')
 end
 
 return M

--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -5,10 +5,7 @@ local M = {}
 local function get_coc_diagnostic(diag_type)
   local has_info,info = pcall(vim.api.nvim_buf_get_var,0,'coc_diagnostic_info')
   if not has_info then return end
-  if info[diag_type] > 0 then
-    return  info[diag_type]
-  end
-  return ''
+  return info[diag_type]
 end
 
 -- nvim-lspconfig
@@ -24,33 +21,42 @@ local function get_nvim_lsp_diagnostic(diag_type)
        count = count + lsp.diagnostic.get_count(api.nvim_get_current_buf(),diag_type,client.id)
     end
 
-    if count ~= 0 then return count .. ' ' end
+    return count
   end
 end
 
-local function get_diagnostic(diag_type)
+function M.get_diagnostic(diag_type)
+  local count = 0
+
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
-    return get_coc_diagnostic(diag_type:lower())
+    count =  get_coc_diagnostic(diag_type:lower())
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic(diag_type)
+    count = get_nvim_lsp_diagnostic(diag_type)
   end
-  return ''
+
+  if count ~= 0 then return count end
+end
+
+local function get_formatted_diagnostic(diag_type)
+  local count = M.get_diagnostic(diag_type)
+
+  if count ~= nil then return count .. ' ' else return '' end
 end
 
 function M.get_diagnostic_error()
-  return get_diagnostic('Error')
+  return get_formatted_diagnostic('Error')
 end
 
 function M.get_diagnostic_warn()
-  return get_diagnostic('Warning')
+  return get_formatted_diagnostic('Warning')
 end
 
 function M.get_diagnostic_hint()
-  return get_diagnostic('Hint')
+  return get_formatted_diagnostic('Hint')
 end
 
 function M.get_diagnostic_info()
-  return get_diagnostic('Information')
+  return get_formatted_diagnostic('Information')
 end
 
 return M

--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -13,16 +13,15 @@ end
 local function get_nvim_lsp_diagnostic(diag_type)
   if next(lsp.buf_get_clients(0)) == nil then return '' end
   local active_clients = lsp.get_active_clients()
+  local count = 0
 
   if active_clients then
-    local count = 0
-
     for _, client in ipairs(active_clients) do
        count = count + lsp.diagnostic.get_count(api.nvim_get_current_buf(),diag_type,client.id)
     end
-
-    return count
   end
+
+  return count
 end
 
 function M.get_diagnostic(diag_type)
@@ -34,13 +33,13 @@ function M.get_diagnostic(diag_type)
     count = get_nvim_lsp_diagnostic(diag_type)
   end
 
-  if count ~= 0 then return count end
+  return count
 end
 
 local function get_formatted_diagnostic(diag_type)
   local count = M.get_diagnostic(diag_type)
 
-  if count ~= nil then return count .. ' ' else return '' end
+  if count ~= 0 then return count .. ' ' else return '' end
 end
 
 function M.get_diagnostic_error()


### PR DESCRIPTION
This changeset exposes a function `get_diagnostic(diag_type)`. It returns a number (unlike `get_diagnostic_*` functions, which return a formatted string).

I did a tiny refactor here, and:

- Both `get_coc_diagnostic` and `get_nvim_lsp_diagnostic` now both return a number (previously both returned a string, but only the former appended a space, which was a minor inconsistency).
- I've de-duplicated some logic by introducing `get_formatted_diagnostic`. It also ensures all values are formatted the same.

This is mostly since I want to be able to use something like `get_diagnostic("Info") + get_diagnostic("Hint")`. The existing functions return strings, so doing math on them is unnecessarily complicated.