### PR TITLE
New shortline options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The type of all of these section variables:
 - `require('galaxyline').short_line_list` some special filetypes that show a
     short statusline like `LuaTree defx coc-explorer vista` etc.
 
+- `require('galaxyline').short_line_buftypes` list of buftypes that act like `short_line_list`
+
 - `require('galaxyline').section.left` the statusline left section.
 
 - `require('galaxyline').section.mid` the statusline mid section.
@@ -49,6 +51,8 @@ The type of all of these section variables:
 
 - `require('galaxyline').section.short_line_right` statusline right section when
     filetype is in `short_line_list` and for inactive window
+
+- `require('galaxyline').inactive_window_shortline` whether inactive windows should use short statusline (default: `true`)
 
 
 ### Component keyword

--- a/lua/galaxyline.lua
+++ b/lua/galaxyline.lua
@@ -9,6 +9,8 @@ M.section.mid = {}
 M.section.short_line_left = {}
 M.section.short_line_right = {}
 M.short_line_list = {}
+M.short_line_buftypes = {}
+M.inactive_window_shortline = true
 
 _G.galaxyline_providers = {}
 
@@ -206,6 +208,8 @@ async_combin = uv.new_async(vim.schedule_wrap(function()
 
   if vim.fn.index(M.short_line_list,vim.bo.filetype) ~= -1 then
     line = short_line
+  elseif vim.fn.index(M.short_line_buftypes,vim.bo.buftype) ~= -1 then
+    line = short_line
   end
 
   vim.wo.statusline = line
@@ -217,7 +221,11 @@ function M.load_galaxyline()
 end
 
 function M.inactive_galaxyline()
-  if next(M.short_line_list) == nil then
+  if not M.inactive_window_shortline then
+    return
+  end
+
+  if next(M.short_line_list) == nil and next(M.short_line_buftypes) == nil then
     vim.wo.statusline = normal_line
   else
     vim.wo.statusline = short_line

--- a/lua/galaxyline/provider_fileinfo.lua
+++ b/lua/galaxyline/provider_fileinfo.lua
@@ -185,6 +185,12 @@ function M.filename_in_special_buffer()
       return ''
     end
   end
+  local short_list_buftypes = require('galaxyline').short_list_buftypes
+  for _,v in ipairs(short_list_buftypes) do
+    if v == vim.bo.buftype then
+      return ''
+    end
+  end
   return fname
 end
 


### PR DESCRIPTION
* Add `short_line_buftypes` acting like `short_line_list` but reading `vim.bo.buftype`. (closes #156)
* Add `inactive_window_shortline`. When toggled off, inactive windows keep their regular statusline.