### PR TITLE
Fix deprecated diagnostics api

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ componentizes Vim's statusline by having a provider for each text area.
 This means you can use the api provided by galaxyline to create the statusline
 that you want, easily.
 
-**Requires neovim 0.5.0+**
+**Requires neovim 0.6.0+**
 
 ## Install
 * vim-plug
@@ -90,7 +90,7 @@ local buffer = require('galaxyline.provider_buffer')
 local whitespace = require('galaxyline.provider_whitespace')
 local lspclient = require('galaxyline.provider_lsp')
 
--- provider 
+-- provider
 BufferIcon  = buffer.get_buffer_type_icon,
 BufferNumber = buffer.get_buffer_number,
 FileTypeName = buffer.get_buffer_filetype,
@@ -133,7 +133,7 @@ local condition = require('galaxyline.condition')
 condition.buffer_not_empty  -- if buffer not empty return true else false
 condition.hide_in_width  -- if winwidth(0)/ 2 > 40 true else false
 -- find git root, you can use this to check if the project is a git workspace
-condition.check_git_workspace() 
+condition.check_git_workspace()
 
 -- built-in theme
 local colors = require('galaxyline.theme').default

--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -18,11 +18,7 @@ local function get_nvim_lsp_diagnostic(diag_type)
   local active_clients = lsp.get_active_clients()
 
   if active_clients then
-    local count = 0
-
-    for _, client in ipairs(active_clients) do
-       count = count + lsp.diagnostic.get_count(api.nvim_get_current_buf(),diag_type,client.id)
-    end
+    local count = #vim.diagnostic.get(api.nvim_get_current_buf(),{severity=diag_type})
 
     if count ~= 0 then return count .. ' ' end
   end
@@ -32,7 +28,7 @@ function M.get_diagnostic_error()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('error')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Error')
+    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.ERROR)
   end
   return ''
 end
@@ -41,7 +37,7 @@ function M.get_diagnostic_warn()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('warning')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Warning')
+    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.WARN)
   end
   return ''
 end
@@ -50,7 +46,7 @@ function M.get_diagnostic_hint()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('hint')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Hint')
+    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.HINT)
   end
   return ''
 end
@@ -59,7 +55,7 @@ function M.get_diagnostic_info()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('information')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Information')
+    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.INFO)
   end
   return ''
 end


### PR DESCRIPTION
0.6 release deprecated vim.api.diagnostics in favour of vim.diagnostics. See [this link](https://github.com/neovim/neovim/blob/c4d70dae802ef074aaf54bdcbbd5f73380f74a86/runtime/lua/vim/lsp/diagnostic.lua#L344) for details