### PR TITLE
fix: use vim.diagnostic as default provider

### DIFF
--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -15,7 +15,14 @@ end
 -- nvim-lspconfig
 -- see https://github.com/neovim/nvim-lspconfig
 local function get_nvim_lsp_diagnostic(severity)
-  return vim.tbl_count(diag.get(0, { severity = severity }))
+  if next(lsp.buf_get_clients(0)) == nil then return '' end
+  local active_clients = lsp.get_active_clients()
+
+  if active_clients then
+    local count = vim.tbl_count(diag.get(0, { severity = severity }))
+
+    if count ~= 0 then return count .. ' ' end
+  end
 end
 
 function M.get_diagnostic_error()

--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -1,4 +1,5 @@
-local vim,lsp,api = vim,vim.lsp,vim.api
+local vim,lsp = vim,vim.lsp
+local diag = vim.diagnostic
 local M = {}
 
 -- coc diagnostic
@@ -13,26 +14,15 @@ end
 
 -- nvim-lspconfig
 -- see https://github.com/neovim/nvim-lspconfig
-local function get_nvim_lsp_diagnostic(diag_type)
-  if next(lsp.buf_get_clients(0)) == nil then return '' end
-  local active_clients = lsp.get_active_clients()
-
-  if active_clients then
-    local count = 0
-
-    for _, client in ipairs(active_clients) do
-       count = count + lsp.diagnostic.get_count(api.nvim_get_current_buf(),diag_type,client.id)
-    end
-
-    if count ~= 0 then return count .. ' ' end
-  end
+local function get_nvim_lsp_diagnostic(severity)
+  return vim.tbl_count(diag.get(0, { severity = severity }))
 end
 
 function M.get_diagnostic_error()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('error')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Error')
+    return get_nvim_lsp_diagnostic(diag.severity.ERROR)
   end
   return ''
 end
@@ -41,7 +31,7 @@ function M.get_diagnostic_warn()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('warning')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Warning')
+    return get_nvim_lsp_diagnostic(diag.severity.WARN)
   end
   return ''
 end
@@ -50,7 +40,7 @@ function M.get_diagnostic_hint()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('hint')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Hint')
+    return get_nvim_lsp_diagnostic(diag.severity.HINT)
   end
   return ''
 end
@@ -59,7 +49,7 @@ function M.get_diagnostic_info()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('information')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Information')
+    return get_nvim_lsp_diagnostic(diag.severity.INFO)
   end
   return ''
 end


### PR DESCRIPTION
The patch https://github.com/neovim/neovim/commit/c4d70dae802ef074aaf54bdcbbd5f73380f74a86 replace the
`vim.lsp.diagnostic.get_count` with `vim.diagnostic.get`. This patch fix the
deprecated warning.