### PR TITLE
fix vim.lsp.diagnostic deprecated error

### DIFF
--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -1,4 +1,4 @@
-local vim,lsp,api = vim,vim.lsp,vim.api
+local vim,lsp,api,diagnostic = vim,vim.lsp,vim.api,vim.diagnostic
 local M = {}
 
 -- coc diagnostic
@@ -20,8 +20,11 @@ local function get_nvim_lsp_diagnostic(diag_type)
   if active_clients then
     local count = 0
 
-    for _, client in ipairs(active_clients) do
-       count = count + lsp.diagnostic.get_count(api.nvim_get_current_buf(),diag_type,client.id)
+    for _, _ in ipairs(active_clients) do
+      local diagnostics = diagnostic.get(api.nvim_get_current_buf(), { severity = diag_type })
+      for _, _ in pairs(diagnostics) do
+        count = count + 1
+      end
     end
 
     if count ~= 0 then return count .. ' ' end
@@ -32,7 +35,7 @@ function M.get_diagnostic_error()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('error')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Error')
+    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.ERROR)
   end
   return ''
 end
@@ -41,7 +44,7 @@ function M.get_diagnostic_warn()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('warning')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Warning')
+    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.WARN)
   end
   return ''
 end
@@ -50,7 +53,7 @@ function M.get_diagnostic_hint()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('hint')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Hint')
+    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.HINT)
   end
   return ''
 end
@@ -59,7 +62,7 @@ function M.get_diagnostic_info()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('information')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Information')
+    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.INFO)
   end
   return ''
 end

--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -13,7 +13,7 @@ end
 
 -- nvim-lspconfig
 -- see https://github.com/neovim/nvim-lspconfig
-local function get_nvim_lsp_diagnostic(diag_type)
+local function get_nvim_lsp_diagnostic(severity)
   if next(lsp.buf_get_clients(0)) == nil then return '' end
   local active_clients = lsp.get_active_clients()
 
@@ -21,7 +21,7 @@ local function get_nvim_lsp_diagnostic(diag_type)
     local count = 0
 
     for _, _ in ipairs(active_clients) do
-      local diagnostics = diagnostic.get(api.nvim_get_current_buf(), { severity = diag_type })
+      local diagnostics = diagnostic.get(api.nvim_get_current_buf(), { severity = severity })
       for _, _ in pairs(diagnostics) do
         count = count + 1
       end

--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -35,7 +35,7 @@ function M.get_diagnostic_error()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('error')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.ERROR)
+    return get_nvim_lsp_diagnostic(diagnostic.severity.ERROR)
   end
   return ''
 end
@@ -44,7 +44,7 @@ function M.get_diagnostic_warn()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('warning')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.WARN)
+    return get_nvim_lsp_diagnostic(diagnostic.severity.WARN)
   end
   return ''
 end
@@ -53,7 +53,7 @@ function M.get_diagnostic_hint()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('hint')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.HINT)
+    return get_nvim_lsp_diagnostic(diagnostic.severity.HINT)
   end
   return ''
 end
@@ -62,7 +62,7 @@ function M.get_diagnostic_info()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('information')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic(vim.diagnostic.severity.INFO)
+    return get_nvim_lsp_diagnostic(diagnostic.severity.INFO)
   end
   return ''
 end


### PR DESCRIPTION
nvim has deprecated vim.lsp.diagnostic in favor of vim.diagnostic since version 0.6. This change also removed some of the functions available so a loop through all diagnostic is now needed to match the current structure.

I've also changed the hardcoded values of diagnostics to use the values included in nvim, to make it more future proof in case they decide to change these in the future.