### PR TITLE
Use diagnostic.get instead of the deprecated lsp.diagnostic.get_count

### DIFF
--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -1,4 +1,4 @@
-local vim,lsp,api = vim,vim.lsp,vim.api
+local vim,lsp,api,diagnostic = vim,vim.lsp,vim.api,vim.diagnostic
 local M = {}
 
 -- coc diagnostic
@@ -18,12 +18,7 @@ local function get_nvim_lsp_diagnostic(diag_type)
   local active_clients = lsp.get_active_clients()
 
   if active_clients then
-    local count = 0
-
-    for _, client in ipairs(active_clients) do
-       count = count + lsp.diagnostic.get_count(api.nvim_get_current_buf(),diag_type,client.id)
-    end
-
+    local count = #diagnostic.get(vim.api.nvim_get_current_buf(), { severity = diag_type })
     if count ~= 0 then return count .. ' ' end
   end
 end
@@ -32,7 +27,7 @@ function M.get_diagnostic_error()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('error')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Error')
+    return get_nvim_lsp_diagnostic(diagnostic.severity.ERROR)
   end
   return ''
 end
@@ -41,7 +36,7 @@ function M.get_diagnostic_warn()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('warning')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Warning')
+    return get_nvim_lsp_diagnostic(diagnostic.severity.WARN)
   end
   return ''
 end
@@ -50,7 +45,7 @@ function M.get_diagnostic_hint()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('hint')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Hint')
+    return get_nvim_lsp_diagnostic(diagnostic.severity.HINT)
   end
   return ''
 end
@@ -59,7 +54,7 @@ function M.get_diagnostic_info()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('information')
   elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
-    return get_nvim_lsp_diagnostic('Information')
+    return get_nvim_lsp_diagnostic(diagnostic.severity.INFO)
   end
   return ''
 end


### PR DESCRIPTION
lsp.diagnostic.get_count is [deprecated](https://github.com/neovim/neovim/blob/487286b6218ecf4bcf48d0a0089fbc78e2bc5a37/runtime/doc/deprecated.txt#L70) in neovim v0.6.1, and the warning message is super annoying. This cleans that up, and simplifies the code as a bonus :)