### PR TITLE
feat(ISSUE #229): Concatenate all lsp client names found by GetLspClient

### DIFF
--- a/lua/galaxyline/provider_lsp.lua
+++ b/lua/galaxyline/provider_lsp.lua
@@ -6,13 +6,19 @@ local get_lsp_client = function (msg)
     return msg
   end
 
+  local client_name = ''
   for _,client in ipairs(clients) do
     local filetypes = client.config.filetypes
     if filetypes and vim.fn.index(filetypes,buf_ft) ~= -1 then
-      return client.name
+      client_name = client_name .. client.name .. ', '
     end
   end
-  return msg
+  local len = client_name:len()
+  if len > 1 then
+    return client_name:sub(0, len - 2)
+  else
+    return msg
+  end
 end
 
 return {


### PR DESCRIPTION
As described in #229, this pull request fixes the issue. You can now use GetLspClient to retrieve all attached client names instead of only one of them.