### PR TITLE
Fix performance issue when get_git_detached_head() returns nil

### DIFF
--- a/lua/galaxyline/provider_vcs.lua
+++ b/lua/galaxyline/provider_vcs.lua
@@ -162,7 +162,11 @@ function M.get_git_branch()
   if not branch_name then
     -- check if detached head
     branch_name = get_git_detached_head()
-    if not branch_name then return end
+    if not branch_name then
+      -- cache empty as get_git_detached_head() is a heavy operation
+      head_cache[git_root].branch = ""
+      return
+    end
   end
 
   head_cache[git_root].branch = branch_name


### PR DESCRIPTION
When `get_git_detached_head()` returns nil (i.e in the middle of rebasing), get_git_branch lags the cursor movement as `get_git_detached_head()` is being called every move.

Since the function is relatively heavy, we should just cache it until the cache invalidates