### PR TITLE
Add support for global statusline

### DIFF
--- a/lua/galaxyline.lua
+++ b/lua/galaxyline.lua
@@ -2,6 +2,7 @@ local vim = vim
 local uv = vim.loop
 local M = {}
 
+M.global_status_line = false
 M.section = {}
 M.section.left = {}
 M.section.right = {}
@@ -208,7 +209,12 @@ async_combin = uv.new_async(vim.schedule_wrap(function()
     line = short_line
   end
 
-  vim.wo.statusline = line
+  if M.global_status_line then
+    vim.go.statusline = line
+  else
+    vim.wo.statusline = line
+  end
+
   M.init_colorscheme()
 end))
 
@@ -230,7 +236,12 @@ function M.init_colorscheme()
 end
 
 function M.disable_galaxyline()
-  vim.wo.statusline = ''
+  if M.global_status_line then
+    vim.go.statusline = ''
+  else
+    vim.wo.statusline = ''
+  end
+
   vim.api.nvim_command('augroup galaxyline')
   vim.api.nvim_command('autocmd!')
   vim.api.nvim_command('augroup END!')
@@ -243,7 +254,11 @@ function M.galaxyline_augroup()
     local command = string.format('autocmd %s * lua require("galaxyline").load_galaxyline()',def)
     vim.api.nvim_command(command)
   end
-  vim.api.nvim_command('autocmd WinLeave * lua require("galaxyline").inactive_galaxyline()')
+
+  if not M.global_status_line then
+    vim.api.nvim_command('autocmd WinLeave * lua require("galaxyline").inactive_galaxyline()')
+  end
+
   vim.api.nvim_command('augroup END')
 end
 

--- a/lua/galaxyline/condition.lua
+++ b/lua/galaxyline/condition.lua
@@ -33,7 +33,7 @@ function M.hide_in_width()
 end
 
 function M.check_active_lsp()
-  local clients = vim.lsp.buf_get_clients()
+  local clients = vim.lsp.get_clients()
   if next(clients) == nil then
     return false
   end

--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -14,7 +14,7 @@ end
 -- nvim-lspconfig
 -- see https://github.com/neovim/nvim-lspconfig
 local function get_nvim_lsp_diagnostic(diag_type)
-  if next(lsp.buf_get_clients(0)) == nil then return '' end
+  if next(lsp.get_clients({ bufnr = 0 })) == nil then return '' end
   local active_clients = lsp.get_active_clients()
 
   if active_clients then
@@ -26,7 +26,7 @@ end
 function M.get_diagnostic_error()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('error')
-  elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
+  elseif not vim.tbl_isempty(lsp.get_clients({ bufnr = 0 })) then
     return get_nvim_lsp_diagnostic(diagnostic.severity.ERROR)
   end
   return ''
@@ -35,7 +35,7 @@ end
 function M.get_diagnostic_warn()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('warning')
-  elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
+  elseif not vim.tbl_isempty(lsp.get_clients({ bufnr = 0 })) then
     return get_nvim_lsp_diagnostic(diagnostic.severity.WARN)
   end
   return ''
@@ -44,7 +44,7 @@ end
 function M.get_diagnostic_hint()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('hint')
-  elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
+  elseif not vim.tbl_isempty(lsp.get_clients({ bufnr = 0 })) then
     return get_nvim_lsp_diagnostic(diagnostic.severity.HINT)
   end
   return ''
@@ -53,7 +53,7 @@ end
 function M.get_diagnostic_info()
   if vim.fn.exists('*coc#rpc#start_server') == 1 then
     return get_coc_diagnostic('information')
-  elseif not vim.tbl_isempty(lsp.buf_get_clients(0)) then
+  elseif not vim.tbl_isempty(lsp.get_clients({ bufnr = 0 })) then
     return get_nvim_lsp_diagnostic(diagnostic.severity.INFO)
   end
   return ''

--- a/lua/galaxyline/provider_diagnostic.lua
+++ b/lua/galaxyline/provider_diagnostic.lua
@@ -15,7 +15,7 @@ end
 -- see https://github.com/neovim/nvim-lspconfig
 local function get_nvim_lsp_diagnostic(diag_type)
   if next(lsp.get_clients({ bufnr = 0 })) == nil then return '' end
-  local active_clients = lsp.get_active_clients()
+  local active_clients = lsp.get_clients()
 
   if active_clients then
     local result = diagnostic.get(vim.api.nvim_get_current_buf(), { severity = diag_type })

--- a/lua/galaxyline/provider_lsp.lua
+++ b/lua/galaxyline/provider_lsp.lua
@@ -1,7 +1,7 @@
 local get_lsp_client = function (msg)
   msg = msg or 'No Active Lsp'
-  local buf_ft = vim.api.nvim_buf_get_option(0,'filetype')
-  local clients = vim.lsp.get_active_clients()
+  local buf_ft = vim.api.nvim_get_option_value('filetype', {buf = 0})
+  local clients = vim.lsp.get_clients()
   if next(clients) == nil then
     return msg
   end

--- a/plugin/galaxyline.vim
+++ b/plugin/galaxyline.vim
@@ -12,6 +12,10 @@ endif
 
 let g:loaded_galaxyline = 1
 
+if &laststatus == 3
+    lua require('galaxyline').global_status_line = true
+endif
+
 lua require('galaxyline').galaxyline_augroup()
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
When setting 'laststatus = 3', switching window will cause ststusline flickering. This PR add a new boolean option `global_status_line`. When user set this option to true, the WinLeave auto commands won't be enabled.