### PR TITLE
Add install instructions for `lazy.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,26 @@ use({
 })
 ```
 
+- [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+require('lazy').setup({
+  spec = {
+    -- some optional icons
+    { 'nvim-tree/nvim-web-devicons', lazy = true },
+    {
+      'glepnir/galaxyline.nvim',
+        branch = 'main',
+        -- your statusline
+        config = function()
+          require('my_statusline')
+        end,
+    },
+    -- Other plugins
+  },
+})
+```
+
 ## 🧭 Api
 
 ### Section Variables

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ require('lazy').setup({
     },
     -- Other plugins
   },
+  -- Other options for `lazy`
 })
 ```
 


### PR DESCRIPTION
I've added install instructions for folke's [lazy.nvim](https://github.com/folke/lazy.nvim)
and formatted in the same vein. Pretty simple PR, hope you add it for more diversity.

Any issues, please let me know.